### PR TITLE
marks scalaVersion line as tc-skip

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ version := "1.0"
 lazy val `play-webgoat` = (project in file(".")).enablePlugins(PlayScala)
 
 crossScalaVersions := Seq("2.12.8", "2.11.12")
-scalaVersion := crossScalaVersions.value.head
+scalaVersion := crossScalaVersions.value.head // tc-skip
 scalacOptions ++= Seq(
   "-feature", "-unchecked", "-deprecation",
   "-Xfatal-warnings")


### PR DESCRIPTION
This does the same as in #15, but for branch 2.6.x.

Note that this PR is targeting branch 2.6.x, not master. TemplateControl requires the main branch to be 2.6.x for the moment. 

`master` must be removed and all PRs should target 2.6.x.

When Play 2.7.0 is out, the 2.7.x should become the main branch.