### PR TITLE
Fortify: update our GitHub Actions action versions

### DIFF
--- a/.github/workflows/fortify.yml
+++ b/.github/workflows/fortify.yml
@@ -17,14 +17,14 @@ jobs:
         scala: [2.12.x, 2.13.x]
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: coursier/cache-action@v6
-    - uses: actions/setup-java@v2
+    - uses: actions/setup-java@v3
       with:
         distribution: adopt
         java-version: ${{matrix.java}}
 
-    - uses: actions/cache@v2
+    - uses: actions/cache@v3
       env:
         cache-name: fortify
       with:


### PR DESCRIPTION
GitHub is starting to complain they're outdated